### PR TITLE
Add support for lazy JSONPath queries.

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -5,3 +5,4 @@ benchmark
 tests/browser
 docs
 tests/path/cts
+performance/index.js

--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,9 @@ coverage/
 benchmark/*.log
 benchmark/*.txt
 
+# vscode profiler logs
+*.heapprofile
+*.cpuprofile
+
 # dev
 tests/dev.test.ts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # JSON P3 Change Log
 
+## Version 0.3.0 (unreleased)
+
+**Fixes**
+
+- Fixed call stack size issues when querying large datasets with the recursive descent selector. This was mostly due to extending arrays using the spread operator. We now iterate and use `Array.push()`.
+
+**Features**
+
+- Added `jsonpath.lazyQuery()`, a lazy alternative to `jsonpath.query()`. `lazyQuery()` can be faster and more memory efficient if querying large datasets, especially when using recursive descent selectors. Conversely, `query()` is usually the better choice when working with small datasets.
+- `jsonpath.match()` now uses `lazyQuery()` internally, potentially avoiding a lot of unnecessary work.
+
 # Version 0.2.1
 
 **Fixes**

--- a/docs/docs/quick-start.md
+++ b/docs/docs/quick-start.md
@@ -97,6 +97,33 @@ Sally @ $['users'][2]['name']
 Jane @ $['users'][3]['name']
 ```
 
+### Lazy queries
+
+[`lazyQuery()`](./api/namespaces/jsonpath.md#lazyquery) is an alternative to `query()`. `lazyQuery()` can be faster and more memory efficient if querying large datasets, especially when using recursive descent selectors. Conversely, `query()` is usually the better choice when working with small datasets.
+
+`lazyQuery()` returns an iterable sequence of [`JSONPathNode`](./api/classes/jsonpath.JSONPathNode.md) objects which is not a `JSONPathNodeList`.
+
+```javascript
+import { lazyQuery } from "json-p3";
+
+const data = {
+  users: [
+    { name: "Sue", score: 100 },
+    { name: "John", score: 86 },
+    { name: "Sally", score: 84 },
+    { name: "Jane", score: 55 },
+  ],
+};
+
+for (const node of lazyQuery("$.users[?@.score < 100].name", data)) {
+  console.log(node.value);
+}
+
+// John
+// Sally
+// Jane
+```
+
 ### Compilation
 
 `query()` is a convenience function equivalent to `new JSONPathEnvironment().compile(path).query(data)`. Use `jsonpath.compile()` to construct a [`JSONPath`](./api/classes/jsonpath.JSONPath.md) object that can be applied to different data repeatedly.

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -20,7 +20,6 @@
         "allotment": "^1.19.3",
         "clsx": "^1.2.1",
         "docusaurus-plugin-typedoc": "^0.20.1",
-        "json-p3": "^0.2.0",
         "monaco-editor": "^0.43.0",
         "monaco-themes": "^0.4.4",
         "prism-react-renderer": "^1.3.5",
@@ -8304,11 +8303,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
       "integrity": "sha512-CuUqjv0FUZIdXkHPI8MezCnFCdaTAacej1TZYulLoAg1h/PhwkdXFN4V/gzY4g+fMBCOV2xF+rp7t2XD2ns/NQ=="
-    },
-    "node_modules/json-p3": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/json-p3/-/json-p3-0.2.0.tgz",
-      "integrity": "sha512-oF2MCmnrZvO6Iq6ReWDzMRh5s84PuuX44J7TUvJrBiAmeyFO9eJYkQwu4QmuMR0nmRbu9/Mgx2FSz2OISuL7NQ=="
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",

--- a/docs/package.json
+++ b/docs/package.json
@@ -26,7 +26,6 @@
     "allotment": "^1.19.3",
     "clsx": "^1.2.1",
     "docusaurus-plugin-typedoc": "^0.20.1",
-    "json-p3": "^0.2.0",
     "monaco-editor": "^0.43.0",
     "monaco-themes": "^0.4.4",
     "prism-react-renderer": "^1.3.5",

--- a/docs/src/components/JSONPathPlayground/index.js
+++ b/docs/src/components/JSONPathPlayground/index.js
@@ -12,7 +12,7 @@ import "allotment/dist/style.css";
 
 import styles from "./styles.module.css";
 
-import { jsonpath, version as p3version } from "json-p3/dist/json-p3.esm";
+import { jsonpath, version as p3version } from "@site/../dist/json-p3.esm";
 
 const commonEditorOptions = {
   codeLens: false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-p3",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "author": "James Prior",
   "license": "MIT",
   "description": "JSONPath, JSON Pointer and JSON Patch",

--- a/performance/index.js
+++ b/performance/index.js
@@ -1,0 +1,33 @@
+/**
+ * This is incomplete and, thus far, has been used in an adhoc manner.
+ */
+const { performance } = require("perf_hooks");
+const { jsonpath } = require("../dist/json-p3.cjs");
+const cts = require("../tests/path/cts/cts.json");
+
+function validQueries() {
+  return cts.tests
+    .filter((testCase) => testCase.invalid_selector !== true)
+    .map((testCase) => {
+      return [testCase.selector, testCase.document];
+    });
+}
+
+function perf(repeat) {
+  const env = new jsonpath.JSONPathEnvironment();
+  const queries = validQueries();
+  console.log(
+    `repeating ${queries.length} queries on small datasets ${repeat} times`,
+  );
+  const start = performance.now();
+  for (let i = 0; i < repeat; i++) {
+    for (const [query, data] of queries) {
+      env.query(query, data);
+      // Array.from(env.lazyQuery(query, data));
+    }
+  }
+  const stop = performance.now();
+  return (stop - start) / 1e3;
+}
+
+console.log(perf(1000));

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ export {
   Token,
   TokenKind,
   Nothing,
+  lazyQuery,
   query,
   compile,
 } from "./path";

--- a/src/path/environment.ts
+++ b/src/path/environment.ts
@@ -131,6 +131,22 @@ export class JSONPathEnvironment {
   }
 
   /**
+   * A lazy version of {@link query} which is faster and more memory
+   * efficient when querying some large datasets.
+   *
+   * @param path - A JSONPath query to parse and evaluate against _value_.
+   * @param value - Data to which _path_ will be applied.
+   * @returns A sequence of {@link JSONPathNode} objects resulting from
+   * applying _path_ to _value_.
+   */
+  public lazyQuery(
+    path: string,
+    value: JSONValue,
+  ): IterableIterator<JSONPathNode> {
+    return this.compile(path).lazyQuery(value);
+  }
+
+  /**
    * Return a {@link JSONPathNode} instance for the first object found in
    * _value_ matching _path_.
    *

--- a/src/path/expression.ts
+++ b/src/path/expression.ts
@@ -190,7 +190,11 @@ export abstract class JSONPathQuery extends FilterExpression {
 
 export class RelativeQuery extends JSONPathQuery {
   public evaluate(context: FilterContext): JSONPathNodeList {
-    return this.path.query(context.currentValue); // TODO: lazy query?
+    return context.lazy
+      ? new JSONPathNodeList(
+          Array.from(this.path.lazyQuery(context.currentValue)),
+        )
+      : this.path.query(context.currentValue);
   }
 
   public toString(): string {
@@ -200,7 +204,9 @@ export class RelativeQuery extends JSONPathQuery {
 
 export class RootQuery extends JSONPathQuery {
   public evaluate(context: FilterContext): JSONPathNodeList {
-    return this.path.query(context.rootValue); // TODO: lazy query?
+    return context.lazy
+      ? new JSONPathNodeList(Array.from(this.path.lazyQuery(context.rootValue)))
+      : this.path.query(context.rootValue);
   }
 
   public toString(): string {

--- a/src/path/expression.ts
+++ b/src/path/expression.ts
@@ -190,7 +190,7 @@ export abstract class JSONPathQuery extends FilterExpression {
 
 export class RelativeQuery extends JSONPathQuery {
   public evaluate(context: FilterContext): JSONPathNodeList {
-    return this.path.query(context.currentValue);
+    return this.path.query(context.currentValue); // TODO: lazy query?
   }
 
   public toString(): string {
@@ -200,7 +200,7 @@ export class RelativeQuery extends JSONPathQuery {
 
 export class RootQuery extends JSONPathQuery {
   public evaluate(context: FilterContext): JSONPathNodeList {
-    return this.path.query(context.rootValue);
+    return this.path.query(context.rootValue); // TODO: lazy query?
   }
 
   public toString(): string {

--- a/src/path/index.ts
+++ b/src/path/index.ts
@@ -50,6 +50,30 @@ export function query(path: string, value: JSONValue): JSONPathNodeList {
 }
 
 /**
+ * Lazily query JSON value _value_ with JSONPath expression _path_.
+ * Lazy queries can be faster and more memory efficient when querying
+ * large datasets, especially when using recursive decent selectors.
+ *
+ * @param path - A JSONPath expression/query.
+ * @param value - The JSON-like value the JSONPath query is applied to.
+ * @returns A sequence of {@link JSONPathNode} objects resulting from
+ * applying _path_ to _value_.
+ *
+ * @throws {@link JSONPathSyntaxError}
+ * If the path does not conform to standard syntax.
+ *
+ * @throws {@link JSONPathTypeError}
+ * If filter function arguments are invalid, or filter expression are
+ * used in an invalid way.
+ */
+export function lazyQuery(
+  path: string,
+  value: JSONValue,
+): IterableIterator<JSONPathNode> {
+  return DEFAULT_ENVIRONMENT.lazyQuery(path, value);
+}
+
+/**
  * Compile JSONPath _path_ for later use.
  * @param path - A JSONPath expression/query.
  * @returns A path object with a `query()` method.

--- a/src/path/node.ts
+++ b/src/path/node.ts
@@ -6,11 +6,6 @@ import { JSONValue, isString } from "../types";
  */
 export class JSONPathNode {
   /**
-   * The normalized path to this node in the target JSON value.
-   */
-  readonly path: string;
-
-  /**
    * @param value - The JSON value found at _location_.
    * @param location - The parts of a normalized path to _value_.
    * @param root - The target value at the top of the JSON node tree.
@@ -19,10 +14,14 @@ export class JSONPathNode {
     readonly value: JSONValue,
     readonly location: Array<string | number>,
     readonly root: JSONValue,
-  ) {
-    this.path =
+  ) {}
+
+  public get path(): string {
+    return (
       // eslint-disable-next-line prefer-template
-      "$" + location.map((s) => (isString(s) ? `['${s}']` : `[${s}]`)).join("");
+      "$" +
+      this.location.map((s) => (isString(s) ? `['${s}']` : `[${s}]`)).join("")
+    );
   }
 
   /**

--- a/src/path/path.ts
+++ b/src/path/path.ts
@@ -28,11 +28,11 @@ export class JSONPath {
    * @returns
    */
   public query(value: JSONValue): JSONPathNodeList {
-    let nodes = new JSONPathNodeList([new JSONPathNode(value, [], value)]);
+    let nodes = [new JSONPathNode(value, [], value)];
     for (const selector of this.selectors) {
       nodes = selector.resolve(nodes);
     }
-    return nodes;
+    return new JSONPathNodeList(nodes);
   }
 
   /**

--- a/src/path/path.ts
+++ b/src/path/path.ts
@@ -36,6 +36,21 @@ export class JSONPath {
   }
 
   /**
+   *
+   * @param value -
+   * @returns
+   */
+  public lazyQuery(value: JSONValue): IterableIterator<JSONPathNode> {
+    let nodes: IterableIterator<JSONPathNode> = [
+      new JSONPathNode(value, [], value),
+    ][Symbol.iterator]();
+    for (const selector of this.selectors) {
+      nodes = selector.lazyResolve(nodes);
+    }
+    return nodes;
+  }
+
+  /**
    * Return a {@link JSONPathNode} instance for the first object found in
    * _value_ matching this query.
    *
@@ -44,7 +59,10 @@ export class JSONPath {
    * there are no matches.
    */
   public match(value: JSONValue): JSONPathNode | undefined {
-    return this.query(value).nodes.at(0);
+    const it = this.lazyQuery(value);
+    const rv = it.next();
+    if (rv.done) return undefined;
+    return rv.value;
   }
 
   /**

--- a/src/path/selectors.ts
+++ b/src/path/selectors.ts
@@ -495,6 +495,7 @@ export class FilterSelector extends JSONPathSelector {
             environment: this.environment,
             currentValue: value,
             rootValue: node.root,
+            lazy: true,
           };
           if (this.expression.evaluate(filterContext)) {
             yield new JSONPathNode(value, node.location.concat(i), node.root);
@@ -506,6 +507,7 @@ export class FilterSelector extends JSONPathSelector {
             environment: this.environment,
             currentValue: value,
             rootValue: node.root,
+            lazy: true,
           };
           if (this.expression.evaluate(filterContext)) {
             yield new JSONPathNode(value, node.location.concat(key), node.root);

--- a/src/path/types.ts
+++ b/src/path/types.ts
@@ -15,6 +15,7 @@ export type FilterContext = {
   environment: JSONPathEnvironment;
   currentValue: JSONValue;
   rootValue: JSONValue;
+  lazy?: boolean;
 };
 
 /**

--- a/tests/path/errors.test.ts
+++ b/tests/path/errors.test.ts
@@ -82,6 +82,9 @@ describe("recursion limit reached", () => {
     arr.push(data);
     expect(() => env.query(query, data)).toThrow(JSONPathRecursionLimitError);
     expect(() => env.query(query, data)).toThrow("recursion limit reached");
+    expect(() => Array.from(env.lazyQuery(query, data))).toThrow(
+      "recursion limit reached",
+    );
   });
 
   test("nested data with low limit", () => {
@@ -90,5 +93,8 @@ describe("recursion limit reached", () => {
     const data = { foo: [{ bar: [1, 2, 3] }] };
     expect(() => env.query(query, data)).toThrow(JSONPathRecursionLimitError);
     expect(() => env.query(query, data)).toThrow("recursion limit reached");
+    expect(() => Array.from(env.lazyQuery(query, data))).toThrow(
+      "recursion limit reached",
+    );
   });
 });

--- a/tests/path/query.test.ts
+++ b/tests/path/query.test.ts
@@ -1,3 +1,4 @@
+import { JSONPathNodeList } from "../../src/path";
 import { JSONPathEnvironment } from "../../src/path/environment";
 import { JSONPathError } from "../../src/path/errors";
 import { JSONValue } from "../../src/types";
@@ -21,6 +22,22 @@ describe("compliance test suite", () => {
         expect(() => env.compile(selector)).toThrow(JSONPathError);
       } else if (document && result) {
         const rv = env.query(selector, document).values();
+        expect(rv).toStrictEqual(result);
+      }
+    },
+  );
+});
+
+describe("lazy resolution", () => {
+  test.each<Case>(cts.tests)(
+    "$name",
+    ({ selector, document, result, invalid_selector }: Case) => {
+      const env = new JSONPathEnvironment();
+      if (invalid_selector) {
+        expect(() => env.compile(selector)).toThrow(JSONPathError);
+      } else if (document && result) {
+        const it = env.lazyQuery(selector, document);
+        const rv = new JSONPathNodeList(Array.from(it)).values();
         expect(rv).toStrictEqual(result);
       }
     },


### PR DESCRIPTION
`jsonpath.lazyQuery()` is a lazy alternative to `jsonpath.query()`. `lazyQuery()` can be faster and more memory efficient if querying large datasets, especially when using recursive descent selectors. Conversely, `query()` is usually the better choice when working with small datasets.