### PR TITLE
Fix handling of empty node lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # JSON P3 Change Log
 
+# Version 0.3.1
+
+**Fixes**
+
+- Fixed handling of relative and root queries when used as arguments to filter functions. Previously, when those queries resulted in an empty node list, we were converting it to an empty array before passing it to functions that accept _ValueType_ arguments. Now, in such cases, we convert empty node lists to the special result _Nothing_, which is required by the spec.
+
 ## Version 0.3.0
 
 **Fixes**

--- a/src/path/expression.ts
+++ b/src/path/expression.ts
@@ -237,7 +237,7 @@ export class FunctionExtension extends FilterExpression {
       .map((arg, idx) =>
         func.argTypes[idx] !== FunctionExpressionType.NodesType &&
         arg instanceof JSONPathNodeList
-          ? arg.valuesOrSingular()
+          ? this.unpack_node_list(arg)
           : arg,
       );
     return func.call(...args);
@@ -245,6 +245,21 @@ export class FunctionExtension extends FilterExpression {
 
   public toString(): string {
     return `${this.name}(${this.args.map((e) => e.toString()).join(", ")})`;
+  }
+
+  private unpack_node_list(arg: JSONPathNodeList): unknown {
+    switch (arg.length) {
+      case 0:
+        // If the query results in an empty node list, the argument
+        // is the special result Nothing.
+        return Nothing;
+      case 1:
+        // If the query results in a node list consisting of a single
+        // node, the argument is the value of the node
+        return arg.nodes[0].value;
+      default:
+        return arg;
+    }
   }
 }
 


### PR DESCRIPTION
This PR fixes handling of relative (`@..`) and root (`$..`) queries when used as arguments to filter functions. Previously, when those queries resulted in an empty node list, we were converting that node list to an empty array before passing it to functions that accept _ValueType_ arguments. Now, in such cases, we convert empty node lists to the special result _Nothing_, which is required by the spec and is necessary for correct `length()` semantics.

We also update the CTS submodule, which now covers this case. See [jsonpath-compliance-test-suite #53](https://github.com/jsonpath-standard/jsonpath-compliance-test-suite/pull/53).