### PR TITLE
Fix type checks on logical expressions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,14 @@
 
 # Version 0.3.1
 
+**Breaking Changes**
+
+- Changed the error thrown due to non-singular queries in comparison expressions from `JSONPathSyntaxError` to `JSONPathTypeError`.
+
 **Fixes**
 
 - Fixed handling of relative and root queries when used as arguments to filter functions. Previously, when those queries resulted in an empty node list, we were converting it to an empty array before passing it to functions that accept _ValueType_ arguments. Now, in such cases, we convert empty node lists to the special result _Nothing_, which is required by the spec.
+- Fixed well-typedness checks on JSONPath logical expressions (those that involve `&&` or `||`) and non-singular filter queries. Previously we were erroneously applying the checks for comparison expressions to logical expressions too. Now non-singular queries in logical expressions act as an existence test.
 
 ## Version 0.3.0
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-p3",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "author": "James Prior",
   "license": "MIT",
   "description": "JSONPath, JSON Pointer and JSON Patch",

--- a/tests/path/parse.test.ts
+++ b/tests/path/parse.test.ts
@@ -27,6 +27,11 @@ const TEST_CASES: TestCase[] = [
     path: "$[?!(@.a && !@.b)]",
     want: "$[?!(@['a'] && !@['b'])]",
   },
+  {
+    description: "non-singular query in logical expression",
+    path: "$[?@.* && @.b]",
+    want: "$[?(@[*] && @['b'])]",
+  },
 ];
 
 describe("parse", () => {


### PR DESCRIPTION
This PR fixes well-typedness checks on JSONPath logical expressions (those that involve `&&` or `||`) with non-singular filter queries.