### PR TITLE
Fix logical operator precedence.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # Version 1.1.0 (unreleased)
 
+**Fixes**
+
+- Fixed logical operator precedence in JSONPath filter expressions. Previously, logical _or_ (`||`) had a higher precedence than logical _and_ (`&&`). Now `&&` binds more tightly than `||`.
+
 **Features**
 
 - Added `nondeterministic` to `JSONPathEnvironmentOptions` and environment variables to control nondeterminism and the location of `cts.json` when testing for compliance. See the [README](https://github.com/jg-rp/json-p3/blob/main/README.md) for a description of these environment variables.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-p3",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": "James Prior",
   "license": "MIT",
   "description": "JSONPath, JSON Pointer and JSON Patch",

--- a/src/path/parse.ts
+++ b/src/path/parse.ts
@@ -29,8 +29,8 @@ import {
 import { Token, TokenKind, TokenStream } from "./token";
 
 const PRECEDENCE_LOWEST = 1;
-const PRECEDENCE_LOGICAL_AND = 4;
-const PRECEDENCE_LOGICAL_OR = 5;
+const PRECEDENCE_LOGICAL_OR = 4;
+const PRECEDENCE_LOGICAL_AND = 5;
 const PRECEDENCE_COMPARISON = 6;
 const PRECEDENCE_PREFIX = 7;
 


### PR DESCRIPTION
Fix logical operator precedence in JSONPath filter expressions. `&&` should bind more tightly than `||`.