### PR TITLE
Fix lexer error message from unclosed filter expressions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ benchmark/*.txt
 
 # dev
 tests/dev.test.ts
+dev.js
+dev.mjs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # JSON P3 Change Log
 
+## Version 1.1.2 (unreleased)
+
+**Fixes**
+
+- Fixed the error and error message arising from JSONPath queries with filter expressions and a missing closing bracket for the segment. Previously we would get a `JSONPathLexerError`, stating we "can't backup beyond start", which is meant to be an internal error. We now get a `JSONPathSyntaxError` with the message "unclosed bracketed selection".
+
 ## Version 1.1.1
 
 **Fixes**

--- a/src/path/lex.ts
+++ b/src/path/lex.ts
@@ -339,6 +339,8 @@ function lexInsideFilter(l: Lexer): StateFn | null {
     const ch = l.next();
     switch (ch) {
       case "":
+        l.error("unclosed bracketed selection");
+        return null;
       case "]":
         l.filterLevel -= 1;
         if (l.parenStack.length === 1) {

--- a/tests/path/errors.test.ts
+++ b/tests/path/errors.test.ts
@@ -98,3 +98,14 @@ describe("recursion limit reached", () => {
     );
   });
 });
+
+describe("filter expression EOF", () => {
+  const env = new JSONPathEnvironment();
+  test("unclosed bracketed selection", () => {
+    const query = "$.users[?@.score > 85";
+    expect(() => env.query(query, {})).toThrow(JSONPathSyntaxError);
+    expect(() => env.query(query, {})).toThrow(
+      "unclosed bracketed selection ('core > 85':21)",
+    );
+  });
+});


### PR DESCRIPTION
Fix the error and error message arising from JSONPath queries with filter expressions and a missing closing bracket for the segment.

Previously we would get a `JSONPathLexerError`, stating we "can't backup beyond start", which is meant to be an internal error. We now get a `JSONPathSyntaxError` with the message "unclosed bracketed selection".