### PR TITLE
Make sure name selectors return nothing from arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # JSON P3 Change Log
 
+## Version 1.2.1 (unreleased)
+
+**Fixes**
+
+- Fixed JSONPath name selectors that operator on array values. Previously, if a name selector were a quoted digit, we would treat that digit as an array index. The name selector now selects nothing if the target value is an array.
+
 ## Version 1.2.0
 
 **Fixes**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-p3",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "author": "James Prior",
   "license": "MIT",
   "description": "JSONPath, JSON Pointer and JSON Patch",

--- a/src/path/selectors.ts
+++ b/src/path/selectors.ts
@@ -52,7 +52,7 @@ export class NameSelector extends JSONPathSelector {
   public resolve(nodes: JSONPathNode[]): JSONPathNode[] {
     const rv: JSONPathNode[] = [];
     for (const node of nodes) {
-      if (hasStringKey(node.value, this.name)) {
+      if (!isArray(node.value) && hasStringKey(node.value, this.name)) {
         rv.push(
           new JSONPathNode(
             node.value[this.name],
@@ -67,7 +67,7 @@ export class NameSelector extends JSONPathSelector {
 
   public *lazyResolve(nodes: Iterable<JSONPathNode>): Generator<JSONPathNode> {
     for (const node of nodes) {
-      if (hasStringKey(node.value, this.name)) {
+      if (!isArray(node.value) && hasStringKey(node.value, this.name)) {
         yield new JSONPathNode(
           node.value[this.name],
           node.location.concat(this.name),


### PR DESCRIPTION
This PR changes `NameSelector` to ensure a name selector selects nothing from array values.

In JavaScript, `array[0]` is equivalent to `array["0"]` and `Object.hasOwn(array, "0")` can return `true`, so, when resolving a name selector, we have to explicitly check that the target value is not an array.  