### PR TITLE
Improve syntax error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Fixed JSONPath name selectors that operator on array values. Previously, if a name selector were a quoted digit, we would treat that digit as an array index. The name selector now selects nothing if the target value is an array.
 
+**Features**
+
+- Improved handling of JSONPath syntax errors resulting from unbalanced parentheses or empty paren expressions.
+
 ## Version 1.2.0
 
 **Fixes**

--- a/src/path/parse.ts
+++ b/src/path/parse.ts
@@ -359,7 +359,7 @@ export class Parser {
   }
 
   protected parseGroupedExpression(stream: TokenStream): FilterExpression {
-    if (stream.peek.kind == TokenKind.RPAREN) {
+    if (stream.peek.kind === TokenKind.RPAREN) {
       throw new JSONPathSyntaxError(`empty paren expression`, stream.current);
     }
 

--- a/tests/path/errors.test.ts
+++ b/tests/path/errors.test.ts
@@ -38,6 +38,20 @@ describe("syntax error", () => {
       "empty bracketed segment ('$.foo[]':5)",
     );
   });
+  test("empty paren expression", () => {
+    const query = "$[?()]";
+    expect(() => env.query(query, {})).toThrow(JSONPathSyntaxError);
+    expect(() => env.query(query, {})).toThrow(
+      "empty paren expression ('$[?()]':3)",
+    );
+  });
+  test("unbalanced parens", () => {
+    const query = "$[?((@.foo)]";
+    expect(() => env.query(query, {})).toThrow(JSONPathSyntaxError);
+    expect(() => env.query(query, {})).toThrow(
+      "expected an expression, found ']' ('((@.foo)]':11)",
+    );
+  });
 });
 
 describe("type error", () => {


### PR DESCRIPTION
This PR improves handling of JSONPath syntax errors resulting from unbalanced parentheses or empty paren expressions.