### PR TITLE
Map JS RegExp to I-Regexp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # JSON P3 Change Log
 
+## Version 1.3.1 (unreleased)
+
+**Fixes**
+
+- Fixed RegExp to I-Regex pattern mapping with the `match` and `search` filter functions. We now correctly match the special `.` character to everything other than `\r` and `\n`.
+
 ## Version 1.3.0
 
 **Fixes**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-p3",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "author": "James Prior",
   "license": "MIT",
   "description": "JSONPath, JSON Pointer and JSON Patch",

--- a/src/path/lex.ts
+++ b/src/path/lex.ts
@@ -367,6 +367,7 @@ function lexInsideBracketedSelection(l: Lexer): StateFn | null {
     }
 
     if (!l.environment.strict && l.acceptMatchRun(l.environment.keysPattern)) {
+      // FIXME: fall back to legacy behavior if keysPattern is not the default
       switch (l.peek()) {
         case "'":
           l.ignore(); // ~
@@ -377,7 +378,6 @@ function lexInsideBracketedSelection(l: Lexer): StateFn | null {
           l.next();
           return lexDoubleQuoteKeyString(l);
         case "?":
-          l.ignore(); // ~
           l.next();
           l.emit(TokenKind.KEYS_FILTER);
           l.filterLevel += 1;


### PR DESCRIPTION
[CTS #35](https://github.com/jsonpath-standard/jsonpath-compliance-test-suite/pull/35 ) has highlighted some issues with our handling of regular expression patterns passed to the `match` and `search` filter functions.