### PR TITLE
Handle filter expression literals without a comparison expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # JSON P3 Change Log
 
+## Version 1.3.3 (unreleased)
+
+**Fixes**
+
+- Fixed handling of JSONPath filter expression literals. We now throw a `JSONPathSyntaxError` if a filter expression contains a literal (string, int, float, null) that is not part of a comparison or function expression. See [jsonpath-compliance-test-suite #81](https://github.com/jsonpath-standard/jsonpath-compliance-test-suite/pull/81).
+
 ## Version 1.3.2
 
 **Fixes**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-p3",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "author": "James Prior",
   "license": "MIT",
   "description": "JSONPath, JSON Pointer and JSON Patch",

--- a/src/path/parse.ts
+++ b/src/path/parse.ts
@@ -332,12 +332,7 @@ export class Parser {
       }
     }
 
-    if (expr instanceof FilterExpressionLiteral) {
-      throw new JSONPathSyntaxError(
-        "filter expression literals must be compared",
-        expr.token,
-      );
-    }
+    this.throwForLiteral(expr);
 
     return keys
       ? new KeysFilterSelector(
@@ -397,18 +392,8 @@ export class Parser {
       this.throwForNonComparable(left);
       this.throwForNonComparable(right);
     } else {
-      if (left instanceof FilterExpressionLiteral) {
-        throw new JSONPathSyntaxError(
-          "filter expression literals must be compared",
-          left.token,
-        );
-      }
-      if (right instanceof FilterExpressionLiteral) {
-        throw new JSONPathSyntaxError(
-          "filter expression literals must be compared",
-          right.token,
-        );
-      }
+      this.throwForLiteral(left);
+      this.throwForLiteral(right);
     }
 
     return new InfixExpression(tok, left, operator, right);
@@ -580,6 +565,15 @@ export class Parser {
           expr.token,
         );
       }
+    }
+  }
+
+  protected throwForLiteral(expr: FilterExpression): void {
+    if (expr instanceof FilterExpressionLiteral) {
+      throw new JSONPathSyntaxError(
+        `filter expression literals (${expr.toString()}) must be compared`,
+        expr.token,
+      );
     }
   }
 }

--- a/src/path/parse.ts
+++ b/src/path/parse.ts
@@ -3,6 +3,7 @@ import { JSONPathSyntaxError, JSONPathTypeError } from "./errors";
 import {
   BooleanLiteral,
   FilterExpression,
+  FilterExpressionLiteral,
   FunctionExtension,
   InfixExpression,
   LogicalExpression,
@@ -330,6 +331,14 @@ export class Parser {
         );
       }
     }
+
+    if (expr instanceof FilterExpressionLiteral) {
+      throw new JSONPathSyntaxError(
+        "filter expression literals must be compared",
+        expr.token,
+      );
+    }
+
     return keys
       ? new KeysFilterSelector(
           this.environment,
@@ -387,7 +396,21 @@ export class Parser {
     if (COMPARISON_OPERATORS.has(operator)) {
       this.throwForNonComparable(left);
       this.throwForNonComparable(right);
+    } else {
+      if (left instanceof FilterExpressionLiteral) {
+        throw new JSONPathSyntaxError(
+          "filter expression literals must be compared",
+          left.token,
+        );
+      }
+      if (right instanceof FilterExpressionLiteral) {
+        throw new JSONPathSyntaxError(
+          "filter expression literals must be compared",
+          right.token,
+        );
+      }
     }
+
     return new InfixExpression(tok, left, operator, right);
   }
 


### PR DESCRIPTION
We now throw a `JSONPathSyntaxError` if a filter expression contains a literal (string, int, float, null) that is not part of a comparison or function expression.

See [jsonpath-compliance-test-suite #81](https://github.com/jsonpath-standard/jsonpath-compliance-test-suite/pull/81).