### PR TITLE
Unescape strings without JSON.parse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 **Fixes**
 
-- Fixed decoding of JSONPath escape sequences (those found in name selectors and string literals). Previously we were relying on `JSON.parse()` to unescape strings containing escape sequences, now we have our own `unescapeString()` function that rejects invalid surrogate pairs. See [jsonpath-compliance-test-suite #87](https://github.com/jsonpath-standard/jsonpath-compliance-test-suite/pull/87).
+- Fixed decoding of JSONPath escape sequences (those found in name selectors and string literals). Previously we were relying on `JSON.parse()` to unescape strings, now we have our own `unescapeString()` function that rejects invalid codepoints and surrogate pairs. See [jsonpath-compliance-test-suite #87](https://github.com/jsonpath-standard/jsonpath-compliance-test-suite/pull/87).
 
 ## Version 1.3.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # JSON P3 Change Log
 
+## Version 1.3.4
+
+**Fixes**
+
+- Fixed decoding of JSONPath escape sequences (those found in name selectors and string literals). Previously we were relying on `JSON.parse()` to unescape strings containing escape sequences, now we have our own `unescapeString()` function that rejects invalid surrogate pairs. See [jsonpath-compliance-test-suite #87](https://github.com/jsonpath-standard/jsonpath-compliance-test-suite/pull/87).
+
 ## Version 1.3.3
 
 **Fixes**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-p3",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "author": "James Prior",
   "license": "MIT",
   "description": "JSONPath, JSON Pointer and JSON Patch",

--- a/src/path/parse.ts
+++ b/src/path/parse.ts
@@ -576,7 +576,7 @@ export class Parser {
             rv.push("\t");
             break;
           case "u":
-            [codepoint, index] = this.decodeEscapeSequence(value, index, token);
+            [codepoint, index] = this.decodeHexChar(value, index, token);
             rv.push(this.stringFromCodePoint(codepoint, token));
             break;
           default:
@@ -605,7 +605,7 @@ export class Parser {
    * @param token - The token for the string value.
    * @returns - A codepoint, new index tuple.
    */
-  protected decodeEscapeSequence(
+  protected decodeHexChar(
     value: string,
     index: number,
     token: Token,
@@ -620,7 +620,7 @@ export class Parser {
     }
 
     index += 1; // Move past 'u'
-    let codepoint = this.parseInt16(value.slice(index, index + 4), token);
+    let codepoint = this.parseHexDigits(value.slice(index, index + 4), token);
 
     if (isLowSurrogate(codepoint)) {
       throw new JSONPathSyntaxError(
@@ -644,7 +644,7 @@ export class Parser {
         );
       }
 
-      const lowSurrogate = this.parseInt16(
+      const lowSurrogate = this.parseHexDigits(
         value.slice(index + 6, index + 10),
         token,
       );
@@ -675,7 +675,7 @@ export class Parser {
    * Note that we're not using `parseInt(digits, 16)` because it accepts `+`
    * and `-` and things we don't allow.
    */
-  protected parseInt16(digits: string, token: Token): number {
+  protected parseHexDigits(digits: string, token: Token): number {
     const encoder = new TextEncoder();
     let codepoint = 0;
     for (const digit of encoder.encode(digits)) {

--- a/src/path/parse.ts
+++ b/src/path/parse.ts
@@ -548,7 +548,7 @@ export class Parser {
       const ch = value[index];
       if (ch === "\\") {
         // Handle escape sequences
-        index += 1; // Move past '/'
+        index += 1; // Move past '\'
 
         switch (value[index]) {
           case '"':


### PR DESCRIPTION
Until now we've been relying on `JSON.parse()` to decode JSONPath escape sequences (those found in name selectors and string literals), but the JSONPath standard is more strict than `JSON.parse()` when it comes to invalid surrogate pairs, so this PR replaces our use of `JSON.parse()` with our own string unescaping functions.

See https://github.com/jsonpath-standard/jsonpath-compliance-test-suite/pull/87.

TODO:

- [x] Improve error messages
- [x] Test error messages