### PR TITLE
Refactor to model JSONPath segments explicitly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # JSON P3 Change Log
 
+## Version 2.0.0 (unreleased)
+
+**Breaking changes**
+
+These changes should only affect you if you're customizing the JSONPath parser, defining custom JSONPath selectors or inspecting `JSONPath.selectors` (now `JSONPathQuery.segments`). Otherwise query parsing and evaluation remains unchanged. See [issue 11](https://github.com/jg-rp/json-p3/issues/11) for more information.
+
+- Renamed `JSONPath` to `JSONPathQuery` to match terminology from RFC 9535.
+- Refactored `JSONPathQuery` to be composed of `JSONPathSegment`s, each of which is composed of one or more instances of `JSONPathSelector`.
+- Changed abstract method `JSONPathSelector.resolve` and `JSONPathSelector.lazyResolve` to accept a single node argument instead of an array or iterator of nodes. Both still return zero or more nodes.
+
 ## Version 1.3.5
 
 **Fixes**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-p3",
-  "version": "1.3.5",
+  "version": "2.0.0",
   "author": "James Prior",
   "license": "MIT",
   "description": "JSONPath, JSON Pointer and JSON Patch",

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ export * as jsonpath from "./path";
 export {
   DEFAULT_ENVIRONMENT,
   FunctionExpressionType,
-  JSONPath,
+  JSONPathQuery,
   JSONPathEnvironment,
   JSONPathError,
   JSONPathIndexError,

--- a/src/path/environment.ts
+++ b/src/path/environment.ts
@@ -4,7 +4,7 @@ import {
   FilterExpressionLiteral,
   FunctionExtension,
   InfixExpression,
-  JSONPathQuery,
+  FilterQuery,
 } from "./expression";
 import { Count as CountFilterFunction } from "./functions/count";
 import { FilterFunction, FunctionExpressionType } from "./functions/function";
@@ -15,7 +15,7 @@ import { Value as ValueFilterFunction } from "./functions/value";
 import { tokenize } from "./lex";
 import { JSONPathNode, JSONPathNodeList } from "./node";
 import { Parser } from "./parse";
-import { JSONPath } from "./path";
+import { JSONPathQuery } from "./path";
 import { Token, TokenStream } from "./token";
 import { JSONValue } from "../types";
 import { CurrentKey } from "./extra/expression";
@@ -140,10 +140,10 @@ export class JSONPathEnvironment {
 
   /**
    * @param path - A JSONPath query to parse.
-   * @returns A new {@link JSONPath} object, bound to this environment.
+   * @returns A new {@link JSONPathQuery} object, bound to this environment.
    */
-  public compile(path: string): JSONPath {
-    return new JSONPath(
+  public compile(path: string): JSONPathQuery {
+    return new JSONPathQuery(
       this,
       this.parser.parse(new TokenStream(tokenize(this, path))),
     );
@@ -252,7 +252,7 @@ export class JSONPathEnvironment {
             !(
               arg instanceof FilterExpressionLiteral ||
               arg instanceof CurrentKey ||
-              (arg instanceof JSONPathQuery && arg.path.singularQuery()) ||
+              (arg instanceof FilterQuery && arg.path.singularQuery()) ||
               (arg instanceof FunctionExtension &&
                 this.functionRegister.get(arg.name)?.returnType ===
                   FunctionExpressionType.ValueType)
@@ -265,9 +265,7 @@ export class JSONPathEnvironment {
           }
           break;
         case FunctionExpressionType.LogicalType:
-          if (
-            !(arg instanceof JSONPathQuery || arg instanceof InfixExpression)
-          ) {
+          if (!(arg instanceof FilterQuery || arg instanceof InfixExpression)) {
             throw new JSONPathTypeError(
               `${token.value}() argument ${idx} must be of LogicalType`,
               arg.token,
@@ -277,7 +275,7 @@ export class JSONPathEnvironment {
         case FunctionExpressionType.NodesType:
           if (
             !(
-              arg instanceof JSONPathQuery ||
+              arg instanceof FilterQuery ||
               (arg instanceof FunctionExtension &&
                 this.functionRegister.get(arg.name)?.returnType ===
                   FunctionExpressionType.NodesType)

--- a/src/path/expression.ts
+++ b/src/path/expression.ts
@@ -2,7 +2,7 @@ import { deepEquals } from "../deep_equals";
 import { JSONPathTypeError, UndefinedFilterFunctionError } from "./errors";
 import { FunctionExpressionType } from "./functions/function";
 import { JSONPathNodeList } from "./node";
-import { JSONPath } from "./path";
+import { JSONPathQuery } from "./path";
 import { Token } from "./token";
 import { FilterContext, Nothing } from "./types";
 import { isNumber, isString } from "../types";
@@ -190,16 +190,16 @@ export class LogicalExpression extends FilterExpression {
 /**
  * Base class for relative and absolute JSONPath query expressions.
  */
-export abstract class JSONPathQuery extends FilterExpression {
+export abstract class FilterQuery extends FilterExpression {
   constructor(
     readonly token: Token,
-    readonly path: JSONPath,
+    readonly path: JSONPathQuery,
   ) {
     super(token);
   }
 }
 
-export class RelativeQuery extends JSONPathQuery {
+export class RelativeQuery extends FilterQuery {
   public evaluate(context: FilterContext): JSONPathNodeList {
     return context.lazy
       ? new JSONPathNodeList(
@@ -213,7 +213,7 @@ export class RelativeQuery extends JSONPathQuery {
   }
 }
 
-export class RootQuery extends JSONPathQuery {
+export class RootQuery extends FilterQuery {
   public evaluate(context: FilterContext): JSONPathNodeList {
     return context.lazy
       ? new JSONPathNodeList(Array.from(this.path.lazyQuery(context.rootValue)))

--- a/src/path/index.ts
+++ b/src/path/index.ts
@@ -1,12 +1,12 @@
 import { JSONValue } from "../types";
 import { JSONPathEnvironment } from "./environment";
 import { JSONPathNode, JSONPathNodeList } from "./node";
-import { JSONPath } from "./path";
+import { JSONPathQuery } from "./path";
 
 export { JSONPathEnvironment } from "./environment";
 export type { JSONPathEnvironmentOptions } from "./environment";
 
-export { JSONPath } from "./path";
+export { JSONPathQuery } from "./path";
 export { JSONPathNodeList, JSONPathNode } from "./node";
 export { Token, TokenKind } from "./token";
 
@@ -85,7 +85,7 @@ export function lazyQuery(
  * If filter function arguments are invalid, or filter expression are
  * used in an invalid way.
  */
-export function compile(path: string): JSONPath {
+export function compile(path: string): JSONPathQuery {
   return DEFAULT_ENVIRONMENT.compile(path);
 }
 

--- a/src/path/parse.ts
+++ b/src/path/parse.ts
@@ -15,7 +15,7 @@ import {
   StringLiteral,
 } from "./expression";
 import { FunctionExpressionType } from "./functions/function";
-import { JSONPath } from "./path";
+import { JSONPathQuery } from "./path";
 import {
   FilterSelector,
   IndexSelector,
@@ -24,11 +24,7 @@ import {
   SliceSelector,
   WildcardSelector,
 } from "./selectors";
-import {
-  RecursiveDescentSegment,
-  ChildSegment,
-  JSONPathSegment,
-} from "./segments";
+import { DescendantSegment, ChildSegment, JSONPathSegment } from "./segments";
 import { Token, TokenKind, TokenStream } from "./token";
 import { CurrentKey } from "./extra/expression";
 import {
@@ -115,7 +111,7 @@ export class Parser {
           const token = stream.next();
           const selectors = this.parseSelectors(stream);
           segments.push(
-            new RecursiveDescentSegment(this.environment, token, selectors),
+            new DescendantSegment(this.environment, token, selectors),
           );
           break;
         }
@@ -453,7 +449,7 @@ export class Parser {
     const tok = stream.next();
     return new RootQuery(
       tok,
-      new JSONPath(this.environment, this.parseQuery(stream, true)),
+      new JSONPathQuery(this.environment, this.parseQuery(stream, true)),
     );
   }
 
@@ -461,7 +457,7 @@ export class Parser {
     const tok = stream.next();
     return new RelativeQuery(
       tok,
-      new JSONPath(this.environment, this.parseQuery(stream, true)),
+      new JSONPathQuery(this.environment, this.parseQuery(stream, true)),
     );
   }
 

--- a/src/path/path.ts
+++ b/src/path/path.ts
@@ -2,12 +2,12 @@ import { JSONPathEnvironment } from "./environment";
 import { JSONPathNode, JSONPathNodeList } from "./node";
 import { IndexSelector, NameSelector } from "./selectors";
 import { JSONValue } from "../types";
-import { JSONPathSegment, RecursiveDescentSegment } from "./segments";
+import { JSONPathSegment, DescendantSegment } from "./segments";
 
 /**
  *
  */
-export class JSONPath {
+export class JSONPathQuery {
   /**
    *
    * @param environment -
@@ -70,7 +70,7 @@ export class JSONPath {
 
   public singularQuery(): boolean {
     for (const segment of this.segments) {
-      if (segment instanceof RecursiveDescentSegment) return false;
+      if (segment instanceof DescendantSegment) return false;
 
       if (
         segment.selectors.length === 1 &&

--- a/src/path/path.ts
+++ b/src/path/path.ts
@@ -1,12 +1,8 @@
 import { JSONPathEnvironment } from "./environment";
 import { JSONPathNode, JSONPathNodeList } from "./node";
-import {
-  BracketedSelection,
-  IndexSelector,
-  JSONPathSelector,
-  NameSelector,
-} from "./selectors";
+import { IndexSelector, NameSelector } from "./selectors";
 import { JSONValue } from "../types";
+import { JSONPathSegment, RecursiveDescentSegment } from "./segments";
 
 /**
  *
@@ -15,11 +11,11 @@ export class JSONPath {
   /**
    *
    * @param environment -
-   * @param selectors -
+   * @param segments -
    */
   constructor(
     readonly environment: JSONPathEnvironment,
-    readonly selectors: JSONPathSelector[],
+    readonly segments: JSONPathSegment[],
   ) {}
 
   /**
@@ -29,8 +25,8 @@ export class JSONPath {
    */
   public query(value: JSONValue): JSONPathNodeList {
     let nodes = [new JSONPathNode(value, [], value)];
-    for (const selector of this.selectors) {
-      nodes = selector.resolve(nodes);
+    for (const segment of this.segments) {
+      nodes = segment.resolve(nodes);
     }
     return new JSONPathNodeList(nodes);
   }
@@ -44,8 +40,8 @@ export class JSONPath {
     let nodes: IterableIterator<JSONPathNode> = [
       new JSONPathNode(value, [], value),
     ][Symbol.iterator]();
-    for (const selector of this.selectors) {
-      nodes = selector.lazyResolve(nodes);
+    for (const segment of this.segments) {
+      nodes = segment.lazyResolve(nodes);
     }
     return nodes;
   }
@@ -69,19 +65,20 @@ export class JSONPath {
    *
    */
   public toString(): string {
-    return `$${this.selectors.map((s) => s.toString()).join("")}`;
+    return `$${this.segments.map((s) => s.toString()).join("")}`;
   }
 
   public singularQuery(): boolean {
-    for (const selector of this.selectors) {
-      if (selector instanceof NameSelector) continue;
+    for (const segment of this.segments) {
+      if (segment instanceof RecursiveDescentSegment) return false;
+
       if (
-        selector instanceof BracketedSelection &&
-        selector.items.length === 1 &&
-        (selector.items[0] instanceof NameSelector ||
-          selector.items[0] instanceof IndexSelector)
-      )
+        segment.selectors.length === 1 &&
+        (segment.selectors[0] instanceof NameSelector ||
+          segment.selectors[0] instanceof IndexSelector)
+      ) {
         continue;
+      }
       return false;
     }
     return true;

--- a/src/path/segments.ts
+++ b/src/path/segments.ts
@@ -1,0 +1,227 @@
+import { isArray, isObject, isString } from "../types";
+import { JSONPathEnvironment } from "./environment";
+import { JSONPathRecursionLimitError } from "./errors";
+import { JSONPathNode } from "./node";
+import { JSONPathSelector } from "./selectors";
+import { Token } from "./token";
+
+/** Base class for all JSONPath segments. Both shorthand and bracketed. */
+export abstract class JSONPathSegment {
+  constructor(
+    readonly environment: JSONPathEnvironment,
+    readonly token: Token,
+    readonly selectors: JSONPathSelector[],
+  ) {}
+
+  /**
+   * @param nodes - Nodes matched by preceding segments.
+   */
+  public abstract resolve(nodes: JSONPathNode[]): JSONPathNode[];
+
+  /**
+   * @param nodes - Nodes matched by preceding segments.
+   */
+  public abstract lazyResolve(
+    nodes: Iterable<JSONPathNode>,
+  ): Generator<JSONPathNode>;
+
+  /**
+   * Return a canonical string representation of this segment.
+   */
+  public abstract toString(): string;
+}
+
+/** The child selection segment. */
+export class ChildSegment extends JSONPathSegment {
+  public resolve(nodes: JSONPathNode[]): JSONPathNode[] {
+    const rv: JSONPathNode[] = [];
+    for (const node of nodes) {
+      for (const selector of this.selectors) {
+        rv.push(...selector.resolve(node));
+      }
+    }
+    return rv;
+  }
+
+  public *lazyResolve(nodes: Iterable<JSONPathNode>): Generator<JSONPathNode> {
+    for (const node of nodes) {
+      for (const selector of this.selectors) {
+        yield* selector.resolve(node);
+      }
+    }
+  }
+
+  public toString(): string {
+    return `[${this.selectors.map((s) => s.toString()).join(", ")}]`;
+  }
+}
+
+/** The recursive descent segment. */
+export class RecursiveDescentSegment extends JSONPathSegment {
+  public resolve(nodes: JSONPathNode[]): JSONPathNode[] {
+    const rv: JSONPathNode[] = [];
+
+    const visitor = (
+      this.environment.nondeterministic
+        ? this.nondeterministicVisit
+        : this.visit
+    ).bind(this);
+
+    for (const node of nodes) {
+      for (const _node of visitor(node)) {
+        for (const selector of this.selectors) {
+          rv.push(...selector.resolve(_node));
+        }
+      }
+    }
+
+    return rv;
+  }
+
+  public *lazyResolve(nodes: Iterable<JSONPathNode>): Generator<JSONPathNode> {
+    for (const node of nodes) {
+      for (const _node of this.visit(node)) {
+        for (const selector of this.selectors) {
+          yield* selector.resolve(_node);
+        }
+      }
+    }
+  }
+
+  public toString(): string {
+    return `..[${this.selectors.map((s) => s.toString()).join(", ")}]`;
+  }
+
+  private *visit(
+    node: JSONPathNode,
+    depth: number = 1,
+  ): Generator<JSONPathNode> {
+    if (depth >= this.environment.maxRecursionDepth) {
+      throw new JSONPathRecursionLimitError(
+        "recursion limit reached",
+        this.token,
+      );
+    }
+
+    yield node;
+
+    if (isArray(node.value)) {
+      for (let i = 0; i < node.value.length; i++) {
+        const _node = new JSONPathNode(
+          node.value[i],
+          node.location.concat(i),
+          node.root,
+        );
+        yield* this.visit(_node, depth + 1);
+      }
+    } else if (isObject(node.value)) {
+      for (const [key, value] of this.environment.entries(node.value)) {
+        const _node = new JSONPathNode(
+          value,
+          node.location.concat(key),
+          node.root,
+        );
+        yield* this.visit(_node, depth + 1);
+      }
+    }
+  }
+
+  private *nondeterministicVisit(
+    root: JSONPathNode,
+    depth: number = 1,
+  ): Generator<JSONPathNode> {
+    let queue: Array<[JSONPathNode, number]> = Array.from(
+      this.nondeterministicChildren(root),
+    ).map((node) => [node, depth]);
+
+    yield root;
+
+    while (queue.length) {
+      const [node, _depth] = queue.shift() as [JSONPathNode, number];
+      yield node;
+
+      if (_depth >= this.environment.maxRecursionDepth) {
+        throw new JSONPathRecursionLimitError(
+          "recursion limit reached",
+          this.token,
+        );
+      }
+
+      // Visit child nodes now or queue them for later?
+      const visitChildren = Math.random() < 0.5;
+
+      for (const child of this.nondeterministicChildren(node)) {
+        if (visitChildren) {
+          yield child;
+
+          const grandchildren: Array<[JSONPathNode, number]> = Array.from(
+            this.nondeterministicChildren(child),
+          ).map((n) => [n, _depth + 2]);
+
+          queue = interleave(queue, grandchildren);
+        } else {
+          queue.push([child, _depth + 1]);
+        }
+      }
+    }
+  }
+
+  private *nondeterministicChildren(
+    node: JSONPathNode,
+  ): Generator<JSONPathNode> {
+    if (isString(node.value)) return;
+    if (isArray(node.value)) {
+      for (let i = 0; i < node.value.length; i++) {
+        yield new JSONPathNode(
+          node.value[i],
+          node.location.concat(i),
+          node.root,
+        );
+      }
+    } else if (isObject(node.value)) {
+      for (const [key, value] of this.environment.entries(node.value)) {
+        yield new JSONPathNode(value, node.location.concat(key), node.root);
+      }
+    }
+  }
+}
+
+/**
+ * Randomly interleave elements from two arrays while maintaining relative
+ * order of each input array.
+ *
+ * If _arrayA_ is empty, _arrayB_ is returned, and vice versa.
+ */
+function interleave<T, U>(arrayA: T[], arrayB: U[]): Array<T | U> {
+  if (arrayA.length === 0) {
+    return arrayB;
+  }
+
+  if (arrayB.length === 0) {
+    return arrayA;
+  }
+
+  // An array of iterators
+  const iterators: Array<Iterator<T> | Iterator<U>> = [];
+  const itA = arrayA[Symbol.iterator]();
+  const itB = arrayB[Symbol.iterator]();
+
+  for (let i = 0; i < arrayA.length; i++) {
+    iterators.push(itA);
+  }
+
+  for (let i = 0; i < arrayB.length; i++) {
+    iterators.push(itB);
+  }
+
+  shuffle(iterators);
+  return iterators.map((it) => it.next().value);
+}
+
+function shuffle<T>(entries: T[]): T[] {
+  for (let i = entries.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [entries[i], entries[j]] = [entries[j], entries[i]];
+  }
+  return entries;
+}

--- a/src/path/segments.ts
+++ b/src/path/segments.ts
@@ -57,7 +57,7 @@ export class ChildSegment extends JSONPathSegment {
 }
 
 /** The recursive descent segment. */
-export class RecursiveDescentSegment extends JSONPathSegment {
+export class DescendantSegment extends JSONPathSegment {
   public resolve(nodes: JSONPathNode[]): JSONPathNode[] {
     const rv: JSONPathNode[] = [];
 

--- a/src/path/selectors.ts
+++ b/src/path/selectors.ts
@@ -1,10 +1,10 @@
 import { JSONPathEnvironment } from "./environment";
-import { JSONPathIndexError, JSONPathRecursionLimitError } from "./errors";
+import { JSONPathIndexError } from "./errors";
 import { LogicalExpression } from "./expression";
 import { JSONPathNode } from "./node";
 import { Token } from "./token";
 import { FilterContext, hasStringKey } from "./types";
-import { isArray, isObject, JSONValue } from "../types";
+import { isArray, isObject, isString, JSONValue } from "../types";
 
 /**
  * Base class for all JSONPath segments and selectors.
@@ -21,14 +21,12 @@ export abstract class JSONPathSelector {
   /**
    * @param nodes - Nodes matched by preceding selectors.
    */
-  public abstract resolve(nodes: JSONPathNode[]): JSONPathNode[];
+  public abstract resolve(node: JSONPathNode): JSONPathNode[];
 
   /**
    * @param nodes - Nodes matched by preceding selectors.
    */
-  public abstract lazyResolve(
-    nodes: Iterable<JSONPathNode>,
-  ): Generator<JSONPathNode>;
+  public abstract lazyResolve(nodes: JSONPathNode): Generator<JSONPathNode>;
 
   /**
    * Return a canonical string representation of this selector.
@@ -44,41 +42,36 @@ export class NameSelector extends JSONPathSelector {
     readonly environment: JSONPathEnvironment,
     readonly token: Token,
     readonly name: string,
-    readonly shorthand: boolean,
   ) {
     super(environment, token);
   }
 
-  public resolve(nodes: JSONPathNode[]): JSONPathNode[] {
+  public resolve(node: JSONPathNode): JSONPathNode[] {
     const rv: JSONPathNode[] = [];
-    for (const node of nodes) {
-      if (!isArray(node.value) && hasStringKey(node.value, this.name)) {
-        rv.push(
-          new JSONPathNode(
-            node.value[this.name],
-            node.location.concat(this.name),
-            node.root,
-          ),
-        );
-      }
+    if (!isArray(node.value) && hasStringKey(node.value, this.name)) {
+      rv.push(
+        new JSONPathNode(
+          node.value[this.name],
+          node.location.concat(this.name),
+          node.root,
+        ),
+      );
     }
     return rv;
   }
 
-  public *lazyResolve(nodes: Iterable<JSONPathNode>): Generator<JSONPathNode> {
-    for (const node of nodes) {
-      if (!isArray(node.value) && hasStringKey(node.value, this.name)) {
-        yield new JSONPathNode(
-          node.value[this.name],
-          node.location.concat(this.name),
-          node.root,
-        );
-      }
+  public *lazyResolve(node: JSONPathNode): Generator<JSONPathNode> {
+    if (!isArray(node.value) && hasStringKey(node.value, this.name)) {
+      yield new JSONPathNode(
+        node.value[this.name],
+        node.location.concat(this.name),
+        node.root,
+      );
     }
   }
 
   public toString(): string {
-    return this.shorthand ? `['${this.name}']` : `'${this.name}'`;
+    return `'${this.name}'`;
   }
 }
 
@@ -100,36 +93,32 @@ export class IndexSelector extends JSONPathSelector {
     }
   }
 
-  public resolve(nodes: JSONPathNode[]): JSONPathNode[] {
+  public resolve(node: JSONPathNode): JSONPathNode[] {
     const rv: JSONPathNode[] = [];
-    for (const node of nodes) {
-      if (isArray(node.value)) {
-        const normIndex = this.normalizedIndex(node.value.length);
-        if (normIndex in node.value) {
-          rv.push(
-            new JSONPathNode(
-              node.value[normIndex],
-              node.location.concat(normIndex),
-              node.root,
-            ),
-          );
-        }
+    if (isArray(node.value)) {
+      const normIndex = this.normalizedIndex(node.value.length);
+      if (normIndex in node.value) {
+        rv.push(
+          new JSONPathNode(
+            node.value[normIndex],
+            node.location.concat(normIndex),
+            node.root,
+          ),
+        );
       }
     }
     return rv;
   }
 
-  public *lazyResolve(nodes: Iterable<JSONPathNode>): Generator<JSONPathNode> {
-    for (const node of nodes) {
-      if (isArray(node.value)) {
-        const normIndex = this.normalizedIndex(node.value.length);
-        if (normIndex in node.value) {
-          yield new JSONPathNode(
-            node.value[normIndex],
-            node.location.concat(normIndex),
-            node.root,
-          );
-        }
+  public *lazyResolve(node: JSONPathNode): Generator<JSONPathNode> {
+    if (isArray(node.value)) {
+      const normIndex = this.normalizedIndex(node.value.length);
+      if (normIndex in node.value) {
+        yield new JSONPathNode(
+          node.value[normIndex],
+          node.location.concat(normIndex),
+          node.root,
+        );
       }
     }
   }
@@ -157,27 +146,24 @@ export class SliceSelector extends JSONPathSelector {
     this.checkRange(start, stop, step);
   }
 
-  public resolve(nodes: JSONPathNode[]): JSONPathNode[] {
+  public resolve(node: JSONPathNode): JSONPathNode[] {
     const rv: JSONPathNode[] = [];
-    for (const node of nodes) {
-      if (!isArray(node.value)) continue;
+    if (!isArray(node.value)) return rv;
 
-      for (const [i, value] of this.slice(
-        node.value,
-        this.start,
-        this.stop,
-        this.step,
-      )) {
-        rv.push(new JSONPathNode(value, node.location.concat(i), node.root));
-      }
+    for (const [i, value] of this.slice(
+      node.value,
+      this.start,
+      this.stop,
+      this.step,
+    )) {
+      rv.push(new JSONPathNode(value, node.location.concat(i), node.root));
     }
+
     return rv;
   }
 
-  public *lazyResolve(nodes: Iterable<JSONPathNode>): Generator<JSONPathNode> {
-    for (const node of nodes) {
-      if (!isArray(node.value)) continue;
-
+  public *lazyResolve(node: JSONPathNode): Generator<JSONPathNode> {
+    if (isArray(node.value)) {
       for (const [i, value] of this.lazySlice(
         node.value,
         this.start,
@@ -306,249 +292,45 @@ export class WildcardSelector extends JSONPathSelector {
   constructor(
     readonly environment: JSONPathEnvironment,
     readonly token: Token,
-    readonly shorthand: boolean = false,
   ) {
     super(environment, token);
   }
 
-  public resolve(nodes: JSONPathNode[]): JSONPathNode[] {
-    const rv: JSONPathNode[] = [];
-    for (const node of nodes) {
-      if (node.value instanceof String) continue;
-      if (isArray(node.value)) {
-        for (let i = 0; i < node.value.length; i++) {
-          rv.push(
-            new JSONPathNode(node.value[i], node.location.concat(i), node.root),
-          );
-        }
-      } else if (isObject(node.value)) {
-        for (const [key, value] of this.environment.entries(node.value)) {
-          rv.push(
-            new JSONPathNode(value, node.location.concat(key), node.root),
-          );
-        }
-      }
-    }
-    return rv;
-  }
-
-  public *lazyResolve(nodes: Iterable<JSONPathNode>): Generator<JSONPathNode> {
-    for (const node of nodes) {
-      if (node.value instanceof String) continue;
-      if (isArray(node.value)) {
-        for (let i = 0; i < node.value.length; i++) {
-          yield new JSONPathNode(
-            node.value[i],
-            node.location.concat(i),
-            node.root,
-          );
-        }
-      } else if (isObject(node.value)) {
-        for (const [key, value] of this.environment.entries(node.value)) {
-          yield new JSONPathNode(value, node.location.concat(key), node.root);
-        }
-      }
-    }
-  }
-
-  public toString(): string {
-    return this.shorthand ? "[*]" : "*";
-  }
-}
-
-export class RecursiveDescentSegment extends JSONPathSelector {
-  constructor(
-    readonly environment: JSONPathEnvironment,
-    readonly token: Token,
-    readonly selector: JSONPathSelector,
-  ) {
-    super(environment, token);
-  }
-
-  public resolve(nodes: JSONPathNode[]): JSONPathNode[] {
-    const rv: JSONPathNode[] = [];
-
-    if (this.environment.nondeterministic) {
-      for (const root of nodes) {
-        for (const node of this.nondeterministicVisitor(root)) {
-          rv.push(node);
-        }
-      }
-    } else {
-      for (const node of nodes) {
-        rv.push(node);
-        for (const _node of this.visitor(node)) {
-          rv.push(_node);
-        }
-      }
-    }
-
-    return this.selector.resolve(rv);
-  }
-
-  public *lazyResolve(nodes: Iterable<JSONPathNode>): Generator<JSONPathNode> {
-    yield* this.selector.lazyResolve(this._lazyResolve(nodes));
-  }
-
-  // eslint-disable-next-line sonarjs/cognitive-complexity
-  protected *_lazyResolve(
-    nodes: Iterable<JSONPathNode>,
-  ): Generator<JSONPathNode> {
-    for (const _node of nodes) {
-      const stack: Array<{ node: JSONPathNode; depth: number }> = [
-        { node: _node, depth: 0 },
-      ];
-
-      yield _node;
-
-      while (stack.length) {
-        const { node: currentNode, depth } = stack.pop() as {
-          node: JSONPathNode;
-          depth: number;
-        };
-
-        if (depth >= this.environment.maxRecursionDepth) {
-          throw new JSONPathRecursionLimitError(
-            "recursion limit reached",
-            this.token,
-          );
-        }
-
-        if (currentNode.value instanceof String) continue;
-
-        if (isArray(currentNode.value)) {
-          for (let i = 0; i < currentNode.value.length; i++) {
-            const __node = new JSONPathNode(
-              currentNode.value[i],
-              currentNode.location.concat(i),
-              currentNode.root,
-            );
-
-            yield __node;
-
-            if (isObject(__node.value)) {
-              stack.push({ node: __node, depth: depth + 1 });
-            }
-          }
-        } else if (isObject(currentNode.value)) {
-          for (const [key, value] of this.environment.entries(
-            currentNode.value,
-          )) {
-            const __node = new JSONPathNode(
-              value,
-              currentNode.location.concat(key),
-              currentNode.root,
-            );
-
-            yield __node;
-
-            if (isObject(__node.value)) {
-              stack.push({ node: __node, depth: depth + 1 });
-            }
-          }
-        }
-      }
-    }
-  }
-
-  public toString(): string {
-    return `..${this.selector.toString()}`;
-  }
-
-  private visitor(node: JSONPathNode, depth: number = 1): JSONPathNode[] {
-    if (depth >= this.environment.maxRecursionDepth) {
-      throw new JSONPathRecursionLimitError(
-        "recursion limit reached",
-        this.token,
-      );
-    }
+  public resolve(node: JSONPathNode): JSONPathNode[] {
     const rv: JSONPathNode[] = [];
     if (node.value instanceof String) return rv;
     if (isArray(node.value)) {
       for (let i = 0; i < node.value.length; i++) {
-        const _node = new JSONPathNode(
-          node.value[i],
-          node.location.concat(i),
-          node.root,
-        );
-        rv.push(_node);
-        for (const __node of this.visitor(_node, depth + 1)) {
-          rv.push(__node);
-        }
-      }
-    } else if (isObject(node.value)) {
-      for (const [key, value] of this.environment.entries(node.value)) {
-        const _node = new JSONPathNode(
-          value,
-          node.location.concat(key),
-          node.root,
-        );
-        rv.push(_node);
-        for (const __node of this.visitor(_node, depth + 1)) {
-          rv.push(__node);
-        }
-      }
-    }
-
-    return rv;
-  }
-
-  protected nondeterministicVisitor(
-    root: JSONPathNode,
-    depth: number = 1,
-  ): JSONPathNode[] {
-    const rv: JSONPathNode[] = [root];
-    let queue: Array<[JSONPathNode, number]> = this.nondeterministicChildren(
-      root,
-    ).map((node) => [node, depth]);
-
-    while (queue.length) {
-      const [node, _depth] = queue.shift() as [JSONPathNode, number];
-      rv.push(node);
-
-      if (_depth >= this.environment.maxRecursionDepth) {
-        throw new JSONPathRecursionLimitError(
-          "recursion limit reached",
-          this.token,
-        );
-      }
-
-      // Visit child nodes now or queue them for later?
-      const visitChildren = Math.random() < 0.5;
-
-      for (const child of this.nondeterministicChildren(node)) {
-        if (visitChildren) {
-          rv.push(child);
-
-          const grandchildren: Array<[JSONPathNode, number]> =
-            this.nondeterministicChildren(child).map((n) => [n, _depth + 2]);
-
-          queue = interleave(queue, grandchildren);
-        } else {
-          queue.push([child, _depth + 1]);
-        }
-      }
-    }
-
-    return rv;
-  }
-
-  protected nondeterministicChildren(node: JSONPathNode): JSONPathNode[] {
-    const _rv: JSONPathNode[] = [];
-    if (node.value instanceof String) return _rv;
-    if (isArray(node.value)) {
-      for (let i = 0; i < node.value.length; i++) {
-        _rv.push(
+        rv.push(
           new JSONPathNode(node.value[i], node.location.concat(i), node.root),
         );
       }
     } else if (isObject(node.value)) {
       for (const [key, value] of this.environment.entries(node.value)) {
-        _rv.push(new JSONPathNode(value, node.location.concat(key), node.root));
+        rv.push(new JSONPathNode(value, node.location.concat(key), node.root));
       }
     }
+    return rv;
+  }
 
-    return _rv;
+  public *lazyResolve(node: JSONPathNode): Generator<JSONPathNode> {
+    if (isArray(node.value)) {
+      for (let i = 0; i < node.value.length; i++) {
+        yield new JSONPathNode(
+          node.value[i],
+          node.location.concat(i),
+          node.root,
+        );
+      }
+    } else if (isObject(node.value) && !isString(node.value)) {
+      for (const [key, value] of this.environment.entries(node.value)) {
+        yield new JSONPathNode(value, node.location.concat(key), node.root);
+      }
+    }
+  }
+
+  public toString(): string {
+    return "*";
   }
 }
 
@@ -561,75 +343,66 @@ export class FilterSelector extends JSONPathSelector {
     super(environment, token);
   }
 
-  // eslint-disable-next-line sonarjs/cognitive-complexity
-  public resolve(nodes: JSONPathNode[]): JSONPathNode[] {
+  public resolve(node: JSONPathNode): JSONPathNode[] {
     const rv: JSONPathNode[] = [];
-    for (const node of nodes) {
-      if (node.value instanceof String) continue;
-      if (isArray(node.value)) {
-        for (let i = 0; i < node.value.length; i++) {
-          const value = node.value[i];
-          const filterContext: FilterContext = {
-            environment: this.environment,
-            currentValue: value,
-            rootValue: node.root,
-            currentKey: i,
-          };
-          if (this.expression.evaluate(filterContext)) {
-            rv.push(
-              new JSONPathNode(value, node.location.concat(i), node.root),
-            );
-          }
+    if (node.value instanceof String) return rv;
+    if (isArray(node.value)) {
+      for (let i = 0; i < node.value.length; i++) {
+        const value = node.value[i];
+        const filterContext: FilterContext = {
+          environment: this.environment,
+          currentValue: value,
+          rootValue: node.root,
+          currentKey: i,
+        };
+        if (this.expression.evaluate(filterContext)) {
+          rv.push(new JSONPathNode(value, node.location.concat(i), node.root));
         }
-      } else if (isObject(node.value)) {
-        for (const [key, value] of this.environment.entries(node.value)) {
-          const filterContext: FilterContext = {
-            environment: this.environment,
-            currentValue: value,
-            rootValue: node.root,
-            currentKey: key,
-          };
-          if (this.expression.evaluate(filterContext)) {
-            rv.push(
-              new JSONPathNode(value, node.location.concat(key), node.root),
-            );
-          }
+      }
+    } else if (isObject(node.value)) {
+      for (const [key, value] of this.environment.entries(node.value)) {
+        const filterContext: FilterContext = {
+          environment: this.environment,
+          currentValue: value,
+          rootValue: node.root,
+          currentKey: key,
+        };
+        if (this.expression.evaluate(filterContext)) {
+          rv.push(
+            new JSONPathNode(value, node.location.concat(key), node.root),
+          );
         }
       }
     }
     return rv;
   }
 
-  // eslint-disable-next-line sonarjs/cognitive-complexity
-  public *lazyResolve(nodes: Iterable<JSONPathNode>): Generator<JSONPathNode> {
-    for (const node of nodes) {
-      if (node.value instanceof String) continue;
-      if (isArray(node.value)) {
-        for (let i = 0; i < node.value.length; i++) {
-          const value = node.value[i];
-          const filterContext: FilterContext = {
-            environment: this.environment,
-            currentValue: value,
-            rootValue: node.root,
-            lazy: true,
-            currentKey: i,
-          };
-          if (this.expression.evaluate(filterContext)) {
-            yield new JSONPathNode(value, node.location.concat(i), node.root);
-          }
+  public *lazyResolve(node: JSONPathNode): Generator<JSONPathNode> {
+    if (isArray(node.value)) {
+      for (let i = 0; i < node.value.length; i++) {
+        const value = node.value[i];
+        const filterContext: FilterContext = {
+          environment: this.environment,
+          currentValue: value,
+          rootValue: node.root,
+          lazy: true,
+          currentKey: i,
+        };
+        if (this.expression.evaluate(filterContext)) {
+          yield new JSONPathNode(value, node.location.concat(i), node.root);
         }
-      } else if (isObject(node.value)) {
-        for (const [key, value] of this.environment.entries(node.value)) {
-          const filterContext: FilterContext = {
-            environment: this.environment,
-            currentValue: value,
-            rootValue: node.root,
-            lazy: true,
-            currentKey: key,
-          };
-          if (this.expression.evaluate(filterContext)) {
-            yield new JSONPathNode(value, node.location.concat(key), node.root);
-          }
+      }
+    } else if (isObject(node.value) && !isString(node.value)) {
+      for (const [key, value] of this.environment.entries(node.value)) {
+        const filterContext: FilterContext = {
+          environment: this.environment,
+          currentValue: value,
+          rootValue: node.root,
+          lazy: true,
+          currentKey: key,
+        };
+        if (this.expression.evaluate(filterContext)) {
+          yield new JSONPathNode(value, node.location.concat(key), node.root);
         }
       }
     }
@@ -638,86 +411,4 @@ export class FilterSelector extends JSONPathSelector {
   public toString(): string {
     return `?${this.expression.toString()}`;
   }
-}
-
-export type BracketedSegment =
-  | FilterSelector
-  | IndexSelector
-  | NameSelector
-  | SliceSelector
-  | WildcardSelector;
-
-export class BracketedSelection extends JSONPathSelector {
-  constructor(
-    readonly environment: JSONPathEnvironment,
-    readonly token: Token,
-    readonly items: BracketedSegment[],
-  ) {
-    super(environment, token);
-  }
-
-  public resolve(nodes: JSONPathNode[]): JSONPathNode[] {
-    const rv: JSONPathNode[] = [];
-    for (const node of nodes) {
-      for (const item of this.items) {
-        for (const _node of item.resolve([node])) {
-          rv.push(_node);
-        }
-      }
-    }
-
-    return rv;
-  }
-
-  public *lazyResolve(nodes: Iterable<JSONPathNode>): Generator<JSONPathNode> {
-    for (const node of nodes) {
-      for (const item of this.items) {
-        yield* item.lazyResolve([node]);
-      }
-    }
-  }
-
-  public toString(): string {
-    return `[${this.items.map((itm) => itm.toString()).join(", ")}]`;
-  }
-}
-
-/**
- * Randomly interleave elements from two arrays while maintaining relative
- * order of each input array.
- *
- * If _arrayA_ is empty, _arrayB_ is returned, and vice versa.
- */
-function interleave<T, U>(arrayA: T[], arrayB: U[]): Array<T | U> {
-  if (arrayA.length === 0) {
-    return arrayB;
-  }
-
-  if (arrayB.length === 0) {
-    return arrayA;
-  }
-
-  // An array of iterators
-  const iterators: Array<Iterator<T> | Iterator<U>> = [];
-  const itA = arrayA[Symbol.iterator]();
-  const itB = arrayB[Symbol.iterator]();
-
-  for (let i = 0; i < arrayA.length; i++) {
-    iterators.push(itA);
-  }
-
-  for (let i = 0; i < arrayB.length; i++) {
-    iterators.push(itB);
-  }
-
-  shuffle(iterators);
-  return iterators.map((it) => it.next().value);
-}
-
-function shuffle<T>(entries: T[]): T[] {
-  for (let i = entries.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
-    [entries[i], entries[j]] = [entries[j], entries[i]];
-  }
-  return entries;
 }


### PR DESCRIPTION
This PR refactors all JSONPath selectors, defines new JSONPath segments and updates the parser to cope with this new model.

I doubt many (if any) will be defining custom selectors, or traversing built-in selectors from `JSONPath.selectors` (now `JSONPath.segments`), but this will be a breaking change for the API none the less, so will trigger a major version bump. 

See #11. 