### PR TITLE
Fix normalized path for name selectors containing `'` or `\`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # JSON P3 Change Log
 
+## Version 2.0.1 (unreleased)
+
+**Fixes**
+
+- Fixed the string representation (a normalized path) of name selectors containing `'` or `\`. See [issue #30](https://github.com/jg-rp/json-p3/issues/30).
+
 ## Version 2.0.0
 
 **Breaking changes**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "json-p3",
-  "version": "1.3.5",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "json-p3",
-      "version": "1.3.5",
+      "version": "2.0.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/cli": "^7.25.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-p3",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "author": "James Prior",
   "license": "MIT",
   "description": "JSONPath, JSON Pointer and JSON Patch",

--- a/src/path/expression.ts
+++ b/src/path/expression.ts
@@ -23,6 +23,13 @@ export abstract class FilterExpression {
    * Return a string representation of the expression.
    */
   public abstract toString(): string;
+
+  /**
+   * Return a string representation of the expression using shorthand notation where possible.
+   */
+  public toShorthandString(): string {
+    return this.toString();
+  }
 }
 
 /**
@@ -115,6 +122,10 @@ export class PrefixExpression extends FilterExpression {
   public toString(): string {
     return `${this.operator}${this.right.toString()}`;
   }
+
+  public toShorthandString(): string {
+    return `${this.operator}${this.right.toShorthandString()}`;
+  }
 }
 
 export class InfixExpression extends FilterExpression {
@@ -166,6 +177,15 @@ export class InfixExpression extends FilterExpression {
     }
     return `${this.left.toString()} ${this.operator} ${this.right.toString()}`;
   }
+
+  public toShorthandString(): string {
+    if (this.logical) {
+      return `(${this.left.toShorthandString()} ${
+        this.operator
+      } ${this.right.toShorthandString()})`;
+    }
+    return `${this.left.toShorthandString()} ${this.operator} ${this.right.toShorthandString()}`;
+  }
 }
 
 export class LogicalExpression extends FilterExpression {
@@ -184,6 +204,10 @@ export class LogicalExpression extends FilterExpression {
 
   public toString(): string {
     return this.expression.toString();
+  }
+
+  public toShorthandString(): string {
+    return this.expression.toShorthandString();
   }
 }
 
@@ -211,6 +235,10 @@ export class RelativeQuery extends FilterQuery {
   public toString(): string {
     return `@${this.path.toString().slice(1)}`;
   }
+
+  public toShorthandString(): string {
+    return `@${this.path.toShorthandString().slice(1)}`;
+  }
 }
 
 export class RootQuery extends FilterQuery {
@@ -222,6 +250,10 @@ export class RootQuery extends FilterQuery {
 
   public toString(): string {
     return this.path.toString();
+  }
+
+  public toShorthandString(): string {
+    return this.path.toShorthandString();
   }
 }
 
@@ -256,6 +288,10 @@ export class FunctionExtension extends FilterExpression {
 
   public toString(): string {
     return `${this.name}(${this.args.map((e) => e.toString()).join(", ")})`;
+  }
+
+  public toShorthandString(): string {
+    return `${this.name}(${this.args.map((e) => e.toShorthandString()).join(", ")})`;
   }
 
   private unpack_node_list(arg: JSONPathNodeList): unknown {

--- a/src/path/path.ts
+++ b/src/path/path.ts
@@ -62,10 +62,17 @@ export class JSONPathQuery {
   }
 
   /**
-   *
+   * Return the canonical string representation of this query as a normalized path.
    */
   public toString(): string {
     return `$${this.segments.map((s) => s.toString()).join("")}`;
+  }
+
+  /**
+   * Return a string representation of this query using shorthand notation where possible.
+   */
+  public toShorthandString(): string {
+    return `$${this.segments.map((s) => s.toShorthandString()).join("")}`;
   }
 
   public singularQuery(): boolean {

--- a/src/path/selectors.ts
+++ b/src/path/selectors.ts
@@ -32,6 +32,13 @@ export abstract class JSONPathSelector {
    * Return a canonical string representation of this selector.
    */
   public abstract toString(): string;
+
+  /**
+   * Return a string representation of this selector using shorthand notation where possible.
+   */
+  public toShorthandString(): string {
+    return this.toString();
+  }
 }
 
 /**
@@ -410,5 +417,9 @@ export class FilterSelector extends JSONPathSelector {
 
   public toString(): string {
     return `?${this.expression.toString()}`;
+  }
+
+  public toShorthandString(): string {
+    return `?${this.expression.toShorthandString()}`;
   }
 }

--- a/src/path/selectors.ts
+++ b/src/path/selectors.ts
@@ -71,7 +71,7 @@ export class NameSelector extends JSONPathSelector {
   }
 
   public toString(): string {
-    return `'${this.name}'`;
+    return `'${this.name.replace("\\", "\\\\").replace("'", "\\'")}'`;
   }
 }
 

--- a/tests/path/normalized_path.test.ts
+++ b/tests/path/normalized_path.test.ts
@@ -115,6 +115,16 @@ const testCases: Case[] = [
     path: "$[?@.foo == @.bar]",
     want: "$[?@['foo'] == @['bar']]",
   },
+  {
+    description: "issue #30",
+    path: `$["'"]`,
+    want: "$['\\'']",
+  },
+  {
+    description: "quoted name with a slash",
+    path: `$["\\\\"]`,
+    want: "$['\\\\']",
+  },
 ];
 
 describe("parse path", () => {

--- a/tests/path/shorthand_path.test.ts
+++ b/tests/path/shorthand_path.test.ts
@@ -1,0 +1,135 @@
+import { JSONPathError } from "../../src/path";
+import { JSONPathEnvironment } from "../../src/path/environment";
+
+type Case = {
+  description: string;
+  path: string;
+  want: string;
+  error?: boolean;
+};
+
+const testCases: Case[] = [
+  { description: "empty", path: "", want: "", error: true },
+  { description: "just root", path: "$", want: "$" },
+  { description: "root dot", path: "$.", want: "", error: true },
+  { description: "shorthand name", path: "$.foo.bar", want: "$.foo.bar" },
+  {
+    description: "bracketed name, single quotes",
+    path: "$['foo']['bar']",
+    want: "$.foo.bar",
+  },
+  {
+    description: "bracketed name, double quotes",
+    path: "$['foo']['bar']",
+    want: "$.foo.bar",
+  },
+  {
+    description: "dot bracketed",
+    path: "$.['foo']",
+    want: "",
+    error: true,
+  },
+  {
+    description: "index",
+    path: "$[1][9]",
+    want: "$[1][9]",
+  },
+  {
+    description: "slice",
+    path: "$[1:-1]",
+    want: "$[1:-1:1]",
+  },
+  {
+    description: "slice with step",
+    path: "$[1:-1:2]",
+    want: "$[1:-1:2]",
+  },
+  {
+    description: "slice with empty start",
+    path: "$[:-1:2]",
+    want: "$[:-1:2]",
+  },
+  {
+    description: "slice with empty stop",
+    path: "$[1:]",
+    want: "$[1::1]",
+  },
+  {
+    description: "slice with empty start and stop",
+    path: "$[:]",
+    want: "$[::1]",
+  },
+  {
+    description: "wild shorthand",
+    path: "$.foo.*",
+    want: "$.foo.*",
+  },
+  {
+    description: "wild",
+    path: "$.foo[*]",
+    want: "$.foo.*",
+  },
+  {
+    description: "descend",
+    path: "$.foo..[0]",
+    want: "$.foo..[0]",
+  },
+  {
+    description: "bald descend",
+    path: "$.foo..",
+    want: "",
+    error: true,
+  },
+  {
+    description: "multiple selectors",
+    path: "$.foo[1, 2:5, *, 'bar']",
+    want: "$.foo[1, 2:5:1, *, 'bar']",
+  },
+  {
+    description: "filter, relative query",
+    path: "$[?@.foo]",
+    want: "$[?@.foo]",
+  },
+  {
+    description: "filter, logical and",
+    path: "$[?@.foo && @.bar]",
+    want: "$[?(@.foo && @.bar)]",
+  },
+  {
+    description: "filter, logical or",
+    path: "$[?@.foo || @.bar]",
+    want: "$[?(@.foo || @.bar)]",
+  },
+  {
+    description: "filter, logical not",
+    path: "$[?!@.foo]",
+    want: "$[?!@.foo]",
+  },
+  {
+    description: "filter, comparison",
+    path: "$[?@.foo == @.bar]",
+    want: "$[?@.foo == @.bar]",
+  },
+  {
+    description: "issue #30",
+    path: `$["'"]`,
+    want: "$['\\'']",
+  },
+  {
+    description: "quoted name with a slash",
+    path: `$["\\\\"]`,
+    want: "$['\\\\']",
+  },
+];
+
+describe("path to shorthand string", () => {
+  test.each<Case>(testCases)("$description", ({ path, want, error }: Case) => {
+    const env = new JSONPathEnvironment();
+    if (error) {
+      expect(() => env.compile(path)).toThrow(JSONPathError);
+    } else {
+      const _path = env.compile(path);
+      expect(_path.toShorthandString()).toBe(want);
+    }
+  });
+});


### PR DESCRIPTION
Fix normalized path for name selectors containing `'` or `\`. See #30.