### PR TITLE
Fix parsing of filter queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # JSON P3 Change Log
 
+## Version 2.1.1 (unreleased)
+
+**Fixes**
+
+- Fixed parsing of filter queries containing multiple consecutive bracketed segments. Previously we were failing to parse queries like `$[?@[0][1]]`.
+
 ## Version 2.1.0
 
 **Changes**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-p3",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "author": "James Prior",
   "license": "MIT",
   "description": "JSONPath, JSON Pointer and JSON Patch",

--- a/src/path/lex.ts
+++ b/src/path/lex.ts
@@ -392,7 +392,6 @@ function lexInsideBracketedSelection(l: Lexer): StateFn | null {
     switch (ch) {
       case "]":
         l.emit(TokenKind.RBRACKET);
-        if (l.filterLevel) return lexInsideFilter;
         return lexSegment;
       case "":
         l.error("unclosed bracketed selection");

--- a/tests/path/parse.test.ts
+++ b/tests/path/parse.test.ts
@@ -37,6 +37,21 @@ const TEST_CASES: TestCase[] = [
     path: "$[?@.* && @.b]",
     want: "$[?@[*] && @.b]",
   },
+  {
+    description: "filter query, multiple shorthand segments",
+    path: "$[?@.a.b.c]",
+    want: "$[?@.a.b.c]",
+  },
+  {
+    description: "filter query, multiple bracketed segments",
+    path: "$[?@[0][1] && $[2][3]]",
+    want: "$[?@[0][1] && $[2][3]]",
+  },
+  {
+    description: "filter query, dotted and bracketed segments",
+    path: "$[?@.a[1][2] && $.b[2].c[3]]",
+    want: "$[?@.a[1][2] && $.b[2].c[3]]",
+  },
 ];
 
 describe("parse", () => {


### PR DESCRIPTION
This PR fixes parsing of filter queries containing multiple consecutive bracketed segments. Previously we were failing to parse queries like `$[?@[0][1]]`.

First reported at https://github.com/jg-rp/ruby-json-p3/issues/15.