### PR TITLE
Add the `has` function extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # JSON P3 Change Log
 
+## Version 2.2.0 (unreleased)
+
+**Features**
+
+- Added the `has` function extension. `has` accepts two _value types_, a value and a regex pattern, and returns a _logical type_, just like standard `match` and `search` functions. If the first argument is an object, `has` will return `true` if the object has a property name matching the pattern, or `false` otherwise. `has` is not registered by default. See TODO.
+
 ## Version 2.1.1
 
 **Fixes**

--- a/docs/docs/guides/jsonpath-functions.md
+++ b/docs/docs/guides/jsonpath-functions.md
@@ -1,8 +1,16 @@
 # JSONPath Functions
 
+This page describes the JSONPath functions available to the [filter selector](./jsonpath-syntax.md#filters). Some of these functions are defined by [RFC 9535](https://datatracker.ietf.org/doc/html/rfc9535#name-function-extensions) and are available by default. Others are bundled with JSON P3 but need to be explicitly registered with a [`JSONPathEnvironment`](../api/namespaces/jsonpath/classes/JSONPathEnvironment.md). You can create your own [function extensions](#function-extensions) too.
+
+:::info
+The JSONPath specification defines a [type system for function expressions](https://datatracker.ietf.org/doc/html/rfc9535#name-type-system-for-function-ex), and rules for how those types can be used within an expression. JSON P3 will throw a [JSONPathTypeError](../api/namespaces/jsonpath/classes/JSONPathTypeError.md) at query compile time if it contains expressions that are not deemed to be well-typed.
+
+Please see [Section 2.4.3](https://datatracker.ietf.org/doc/html/rfc9535#name-well-typedness-of-function-) _Well-Typedness of Function Expressions_.
+:::
+
 ## Standard functions
 
-These are the standard, built-in functions available to JSONPath [filters](./jsonpath-syntax.md#filters). You can also create your own [function extensions](#function-extensions).
+These are the standard JSONPath [filter selector](./jsonpath-syntax.md#filters) functions defined by RFC 9535. They are registered with every [`JSONPathEnvironment`](../api/namespaces/jsonpath/classes/JSONPathEnvironment.md) by default.
 
 ### `count()`
 
@@ -64,11 +72,37 @@ Return the value associated with the first node in _nodes_, if _nodes_ has exact
 [Filter queries](./jsonpath-syntax.md#filter-queries) that can result in at most one node are known as "singular queries", and all singular queries will be implicitly replaced with their value as required, without the use of `value()`. `value()` is useful when you need the value from a query that can, theoretically, return multiple nodes.
 :::
 
-## Well-typedness
+## Extra functions
 
-The JSONPath specification defines a [type system for function expressions](https://datatracker.ietf.org/doc/html/rfc9535#name-type-system-for-function-ex), and rules for how those types can be used within an expression. JSON P3 will throw a [JSONPathTypeError](../api/namespaces/jsonpath/classes/JSONPathTypeError.md) at query compile time if it contains expressions that are not deemed to be well-typed.
+These are function extensions that are included with JSON P3, but are not registered by default.
 
-Please see [Section 2.4.3](https://datatracker.ietf.org/doc/html/rfc9535#name-well-typedness-of-function-) _Well-Typedness of Function Expressions_.
+### `has()`
+
+```typescript
+search(value: object, pattern: string): boolean
+```
+
+Return `true` if the first argument is an object value and it contains a property name matching the second argument, or `false` otherwise. _pattern_ should be an I-Regexp string.
+
+To use `has()` in your JSONPath queries, register an instance of `jsonpath.functions.Has` with a [`JSONPathEnvironment`](../api/namespaces/jsonpath/classes/JSONPathEnvironment.md).
+
+```js
+import { jsonpath } from "json-p3";
+
+const env = new jsonpath.JSONPathEnvironment();
+env.functionRegister.set("has", new jsonpath.functions.Has());
+
+const data = [{ abc: 1 }, 42, { abb: 2 }, { a_c: 3 }];
+const nodes = env.query(`$[?has(@, 'ab.')]`, data);
+```
+
+By default, instances of `Has` use search semantics. Set the `search` option to `false` when constructing a `Has` instance to use match semantics instead.
+
+```js
+env.functionRegister.set("has", new jsonpath.functions.Has({ search: false }));
+```
+
+See [HasFilterFunctionOptions](../api/namespaces/jsonpath/namespaces/functions/type-aliases/HasFilterFunctionOptions.md) for details of all available option.
 
 ## Function extensions
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-p3",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "author": "James Prior",
   "license": "MIT",
   "description": "JSONPath, JSON Pointer and JSON Patch",

--- a/src/path/functions/index.ts
+++ b/src/path/functions/index.ts
@@ -1,6 +1,7 @@
 export { Count } from "./count";
 export { Length } from "./length";
 export { Match } from "./match";
+export { Has } from "./has";
 export { Search } from "./search";
 export { Value } from "./value";
 export { FunctionExpressionType } from "./function";

--- a/src/path/functions/index.ts
+++ b/src/path/functions/index.ts
@@ -6,5 +6,6 @@ export { Search } from "./search";
 export { Value } from "./value";
 export { FunctionExpressionType } from "./function";
 export type { FilterFunction } from "./function";
+export type { HasFilterFunctionOptions } from "./has";
 export type { MatchFilterFunctionOptions } from "./match";
 export type { SearchFilterFunctionOptions } from "./search";

--- a/src/path/functions/pattern.ts
+++ b/src/path/functions/pattern.ts
@@ -37,3 +37,13 @@ export function mapRegexp(pattern: string): string {
   }
   return parts.join("");
 }
+
+export function fullMatch(pattern: string): string {
+  const parts: string[] = [];
+  const explicitCaret = pattern.startsWith("^");
+  const explicitDollar = pattern.endsWith("$");
+  if (!explicitCaret && !explicitDollar) parts.push("^(?:");
+  parts.push(mapRegexp(pattern));
+  if (!explicitCaret && !explicitDollar) parts.push(")$");
+  return parts.join("");
+}


### PR DESCRIPTION
This PR implements the `has` function extension.

`has` accepts two _value types_, a value and a regex pattern, and returns a _logical type_, just like standard `match` and `search` functions. If the first argument is an object, `has` will return `true` if the object has a property name matching the pattern, or `false` otherwise.

`has` is not registered by default, so must be explicitly added to a `JSONPathEnvironment.functionRegister`.

**Example**

```js
import { jsonpath } from "json-p3";

const env = new jsonpath.JSONPathEnvironment();
env.functionRegister.set("has", new jsonpath.functions.Has());

const data = [{ abc: 1 }, 42, "foo", { abb: 2 }, { a_c: 3 }];
const nodes = env.query(`$[?has(@, 'ab.')]`, data);

console.log(JSON.stringify(nodes.values(), undefined, "  "));
```
**Output**
```
[
  {
    "abc": 1
  },
  {
    "abb": 2
  }
]
```

By default, new instances of `Has()` use search semantics. Setting the `search` constructor option to `false` will enable match semantics instead.

```js
env.functionRegister.set("has", new jsonpath.functions.Has({search: false}));
```

TODO:

- [x] docs

See #37 