### PR TITLE
Fix current key identifier when `strict` is `true`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 ## Version 2.2.0 (unreleased)
 
+**Fixes**
+
+- Fixed a bug where the non-standard current key identifier (`#`) would be accepted when [extra JSONPath syntax](https://jg-rp.github.io/json-p3/guides/jsonpath-extra) is disabled.
+
 **Features**
 
-- Added the `has` function extension. `has` accepts two _value types_, a value and a regex pattern, and returns a _logical type_, just like standard `match` and `search` functions. If the first argument is an object, `has` will return `true` if the object has a property name matching the pattern, or `false` otherwise. `has` is not registered by default. See TODO.
+- Added the `has` function extension ([docs](https://jg-rp.github.io/json-p3/guides/jsonpath-functions)).
 
 ## Version 2.1.1
 

--- a/src/path/lex.ts
+++ b/src/path/lex.ts
@@ -472,6 +472,11 @@ function lexInsideFilter(l: Lexer): StateFn | null {
         l.emit(TokenKind.CURRENT);
         return lexSegment;
       case "#":
+        if (l.environment.strict) {
+          l.backup();
+          l.error(`unexpected filter selector token '${ch}'`);
+          return null;
+        }
         l.emit(TokenKind.CURRENT_KEY);
         return lexSegment;
       case ".":

--- a/tests/path/extra.test.ts
+++ b/tests/path/extra.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from "fs";
 import { JSONPathEnvironment } from "../../src/path/environment";
 import { JSONPathError, JSONPathSyntaxError } from "../../src/path/errors";
 import { JSONValue } from "../../src/types";
+import { compile } from "../../src/path";
 
 type Case = {
   name: string;
@@ -341,4 +342,35 @@ describe("extra docs examples", () => {
       ).toStrictEqual(want);
     },
   );
+});
+
+describe("extra syntax is disabled by default", () => {
+  test("current key", () => {
+    expect(() => compile("$.some[?# > 1]")).toThrow(JSONPathSyntaxError);
+  });
+
+  test("child keys", () => {
+    expect(() => compile("$.some[~]")).toThrow(JSONPathSyntaxError);
+  });
+
+  test("shorthand keys", () => {
+    expect(() => compile("$.some.~")).toThrow(JSONPathSyntaxError);
+  });
+
+  test("recursive keys", () => {
+    expect(() => compile("$..~")).toThrow(JSONPathSyntaxError);
+  });
+
+  test("just a key", () => {
+    expect(() => compile("$.some[~'other']")).toThrow(JSONPathSyntaxError);
+  });
+  test("just a key, shorthand", () => {
+    expect(() => compile("$.some.~other")).toThrow(JSONPathSyntaxError);
+  });
+
+  test("filter keys", () => {
+    expect(() => compile("$.some[~?match(@, '^b.*')]")).toThrow(
+      JSONPathSyntaxError,
+    );
+  });
 });


### PR DESCRIPTION
This PR fixes a bug where the non-standard current key identifier (`#`) would be accepted when [extra JSONPath syntax](https://jg-rp.github.io/json-p3/guides/jsonpath-extra) is disabled.