### PR TITLE
Update iregexp-check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # JSON P3 Change Log
 
+## Version 2.2.1
+
+**Fixes**
+
+- Update iregexp-check to fix range quantifiers with multiple digits. See [issue 40](https://github.com/jg-rp/json-p3/issues/40).
+
 ## Version 2.2.0
 
 **Fixes**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "json-p3",
-  "version": "2.0.0",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "json-p3",
-      "version": "2.0.0",
+      "version": "2.2.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/cli": "^7.25.9",
@@ -39,7 +39,7 @@
         "eslint-plugin-promise": "^6.6.0",
         "eslint-plugin-sonarjs": "^0.23.0",
         "eslint-plugin-tsdoc": "^0.2.17",
-        "iregexp-check": "^0.1.1",
+        "iregexp-check": "^0.1.2",
         "jest": "^29.7.0",
         "prettier": "^3.4.2",
         "rollup": "^4.28.0",
@@ -6725,9 +6725,9 @@
       }
     },
     "node_modules/iregexp-check": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/iregexp-check/-/iregexp-check-0.1.1.tgz",
-      "integrity": "sha512-uIFoJ9UV96yhZY3Gp9PAg2UJ5iNGH9+695QqXq/vab2u4cTSur+4EAmxIY2ZafIJc8wRaQe27N3TxQ1yxcJitQ==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/iregexp-check/-/iregexp-check-0.1.2.tgz",
+      "integrity": "sha512-RCcV2SFO5JKh+DdmWiY7yVyiZzzk6XZiHEJvTKbzVs8Z0u404gnoSqDtFqg6C5qJBEG4QseWBQz9zhI68zskEQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-p3",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "author": "James Prior",
   "license": "MIT",
   "description": "JSONPath, JSON Pointer and JSON Patch",
@@ -67,7 +67,7 @@
     "eslint-plugin-promise": "^6.6.0",
     "eslint-plugin-sonarjs": "^0.23.0",
     "eslint-plugin-tsdoc": "^0.2.17",
-    "iregexp-check": "^0.1.1",
+    "iregexp-check": "^0.1.2",
     "jest": "^29.7.0",
     "prettier": "^3.4.2",
     "rollup": "^4.28.0",

--- a/tests/path/issues.test.ts
+++ b/tests/path/issues.test.ts
@@ -1,0 +1,13 @@
+import { query } from "../../src/path";
+
+describe("issues", () => {
+  test("issue 40", () => {
+    const data = { a: "d449f7a5-9153-4f39-a05d-dca1c35538ec" };
+    const path =
+      '$[?search(@, "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{10}")]';
+    const nodes = query(path, data);
+    expect(nodes.values()).toStrictEqual([
+      "d449f7a5-9153-4f39-a05d-dca1c35538ec",
+    ]);
+  });
+});


### PR DESCRIPTION
Update iregexp-check to fix range quantifiers with multiple digits. See #40.