### PR TITLE
Fix unbalanced parentheses 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # JSON P3 Change Log
 
+## Version 2.2.2
+
+**Fixes**
+
+- Fixed an issue where we'd get syntax errors claiming "unbalanced parentheses" when the query has balanced brackets.
+
 ## Version 2.2.1
 
 **Fixes**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-p3",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "author": "James Prior",
   "license": "MIT",
   "description": "JSONPath, JSON Pointer and JSON Patch",

--- a/tests/path/errors.test.ts
+++ b/tests/path/errors.test.ts
@@ -1,4 +1,4 @@
-import { JSONValue } from "../../src";
+import { compile, JSONValue } from "../../src";
 import { JSONPathEnvironment } from "../../src/path/environment";
 import {
   JSONPathIndexError,
@@ -49,7 +49,7 @@ describe("syntax error", () => {
     const query = "$[?((@.foo)]";
     expect(() => env.query(query, {})).toThrow(JSONPathSyntaxError);
     expect(() => env.query(query, {})).toThrow(
-      "expected an expression, found ']' ('((@.foo)]':11)",
+      "unbalanced brackets ('((@.foo)]':11)",
     );
   });
 });
@@ -181,6 +181,12 @@ describe("escape sequence decode errors", () => {
     expect(() => env.query(query, {})).toThrow(JSONPathSyntaxError);
     expect(() => env.query(query, {})).toThrow(
       "invalid \\uXXXX escape sequence ('$['ab\\u26':3)",
+    );
+  });
+
+  test("well-typed nested functions, unbalanced parens", () => {
+    expect(() => compile("$.values[?match(@.a, value($..['regex'])]")).toThrow(
+      JSONPathSyntaxError,
     );
   });
 });

--- a/tests/path/issues.test.ts
+++ b/tests/path/issues.test.ts
@@ -12,6 +12,7 @@ describe("issues", () => {
   });
 
   test("issue 42", () => {
+    // This was failing with an "unbalanced parentheses" syntax error.
     expect(compile("$[? count(@.likes[? @.location]) > 3]")).toBeInstanceOf(
       JSONPathQuery,
     );

--- a/tests/path/issues.test.ts
+++ b/tests/path/issues.test.ts
@@ -1,0 +1,9 @@
+import { compile, JSONPathQuery } from "../../src";
+
+describe("issues", () => {
+  test("issue 42", () => {
+    expect(compile("$[? count(@.likes[? @.location]) > 3]")).toBeInstanceOf(
+      JSONPathQuery,
+    );
+  });
+});

--- a/tests/path/parse.test.ts
+++ b/tests/path/parse.test.ts
@@ -1,9 +1,4 @@
-import {
-  JSONPathEnvironment,
-  JSONPathSyntaxError,
-  compile,
-  query,
-} from "../../src/path";
+import { JSONPathEnvironment, query } from "../../src/path";
 
 type TestCase = {
   description: string;
@@ -78,11 +73,5 @@ describe("parse", () => {
     };
     const rv = query("$.values[?match(@.a, value($..['regex']))]", data);
     expect(rv.values()).toStrictEqual([{ a: "ab" }]);
-  });
-
-  test("well-typed nested functions, unbalanced parens", () => {
-    expect(() => compile("$.values[?match(@.a, value($..['regex'])]")).toThrow(
-      JSONPathSyntaxError,
-    );
   });
 });


### PR DESCRIPTION
This PR fixes an issue where we'd get syntax errors claiming "unbalanced parentheses" when the query has balanced brackets.

See #42.